### PR TITLE
Add support for port ranges in REDIRECT_PORTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ services:
       - DOH_SERVERS=quad9-doh-ip4-port443-nofilter-ecs-pri, quad9-doh-ip4-port443-nofilter-pri # Server-List: https://dnscrypt.info/public-servers/
       - FALL_BACK_DNS=9.9.9.9
       # FIREWALL:
-      - REDIRECT_PORTS=all # Only certain port, e.g. REDIRECT_PORTS=21,80,443
+      - REDIRECT_PORTS=all # Only certain port, e.g. REDIRECT_PORTS=21,80,443 or ranges REDIRECT_PORTS=21,80,443,8000-9000
       - ALLOW_DOCKER_CIDR=true # Allow networking between containers
       - LIMIT_UDP=true # Drop outgoing UDP traffic (DNS is whitelisted)
       # REDSOCKS:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,17 @@ export SPLICE=${SPLICE:-false}
 
 is_valid_port() {
     local port="$1"
-    [[ "$port" =~ ^[0-9]+$ ]] && [ "$port" -ge 1 ] && [ "$port" -le 65535 ]
+    if [[ "$port" =~ ^[0-9]+$ ]]; then
+        (( port >= 1 && port <= 65535 ))
+        return
+    fi
+    if [[ "$port" =~ ^([0-9]+):([0-9]+)$ ]]; then
+        local start="${BASH_REMATCH[1]}"
+        local end="${BASH_REMATCH[2]}"
+        (( start >= 1 && end <= 65535 && start <= end ))
+        return
+    fi
+    return 1
 }
 
 setup_dnscrypt() {
@@ -105,7 +115,7 @@ configure_iptables() {
         echo "  - Redirecting all TCP traffic"
         iptables -t nat -A REDSOCKS -p tcp -j REDIRECT --to-port "$LOCAL_PORT"
     else
-        REDIRECT_PORTS=$(echo "$REDIRECT_PORTS" | sed 's/[[:space:]]//g')
+        REDIRECT_PORTS=$(echo "$REDIRECT_PORTS" | sed 's/[[:space:]]//g; s/-/:/g')
         IFS=',' read -ra PORTS <<< "$REDIRECT_PORTS"
         echo "  - Redirecting TCP Ports:"
         for PORT in "${PORTS[@]}"; do


### PR DESCRIPTION
Allow REDIRECT_PORTS to use port ranges via either `start:end` or `start-end` formatted values.

The existing `configure_iptables()` already supports colon-separated port ranges but the port number validation function `is_valid()` did not accept range values and halted processing.

This small change allows port range values to pass the input validation check and processing to continue.

Additionally it amends the REDIRECT_PORTS normalisation to convert dash-separated ranges into colon-separated ranges as dashes are often used when defining ports ranges and should be supported.

This closes issue #43.